### PR TITLE
use a custom hi group instead of StatusLine

### DIFF
--- a/lua/bubbly/factories/bubble.lua
+++ b/lua/bubbly/factories/bubble.lua
@@ -61,7 +61,7 @@ return function(list)
          bubble = bubble..e.data:gsub('^%s*(.-)%s*$', '%1')
          if not islast then bubble = bubble..' ' end
          -- render right delimiter
-         if islast then bubble = bubble..render_delimiter(settings.right_character, e.color)..'%#StatusLine#' end
+         if islast then bubble = bubble..render_delimiter(settings.right_character, e.color)..'%#BubblyStatusLine#' end
          -- render post
          bubble = bubble..e.post
          -- disable isfirst

--- a/lua/bubbly/factories/highlight.lua
+++ b/lua/bubbly/factories/highlight.lua
@@ -38,6 +38,6 @@
             define_bubble_highlight('Bubbly'..titlecase(k1), v1, palette.background, palette.background)
          end
       end
-      autocmd('StatusLine', palette.foreground, palette.background)
-      autocmd('TabLine', palette.foreground, palette.background)
+      autocmd('BubblyStatusLine', palette.foreground, palette.background)
+      autocmd('BubblyTabLine', palette.foreground, palette.background)
    end


### PR DESCRIPTION
Using a custom highlight group, the original StatusLine color definitions are not changed.
In this way, on `colorscheme` change, the statusline colors are automatically updated accordingly (In particular changed from `set background=dark` to `light`).