### PR TITLE
Recompute highlights on VimEnter and ColorScheme events

### DIFF
--- a/lua/bubbly/factories/highlight.lua
+++ b/lua/bubbly/factories/highlight.lua
@@ -13,15 +13,15 @@
 -- Auxiliars definition
 -- ====================
    -- Define autocmd auxiliar function
-   local function autocmd(name, foreground, background, style)
-      vim.cmd('autocmd ColorScheme,VimEnter * '..highlight(name, foreground, background, style))
+   local function execute_command(name, foreground, background, style)
+      vim.cmd(highlight(name, foreground, background, style))
    end
    -- Define bubble highlight
    local function define_bubble_highlight(name, foreground, background, default_background)
-      autocmd(name, background, foreground)
-      autocmd(name..'Bold', background, foreground, 'bold')
-      autocmd(name..'Italic', background, foreground, 'italic')
-      autocmd(name..'Delimiter', foreground, default_background)
+      execute_command(name, background, foreground)
+      execute_command(name..'Bold', background, foreground, 'bold')
+      execute_command(name..'Italic', background, foreground, 'italic')
+      execute_command(name..'Delimiter', foreground, default_background)
    end
 -- ==================
 -- Factory definition
@@ -38,6 +38,6 @@
             define_bubble_highlight('Bubbly'..titlecase(k1), v1, palette.background, palette.background)
          end
       end
-      autocmd('BubblyStatusLine', palette.foreground, palette.background)
-      autocmd('BubblyTabLine', palette.foreground, palette.background)
+      execute_command('BubblyStatusLine', palette.foreground, palette.background)
+      execute_command('BubblyTabLine', palette.foreground, palette.background)
    end

--- a/plugin/bubbly.vim
+++ b/plugin/bubbly.vim
@@ -10,7 +10,11 @@
 " ====================
 " Highlight definition
 " ====================
-  lua require'bubbly.highlight'()
+  lua _G.bubbly_highlight = require'bubbly.highlight'
+  augroup BubblyHighlight
+    autocmd!
+    autocmd VimEnter,ColorScheme * v:lua.bubbly_highlight()
+  augroup end
 " ======================
 " Autocommand definition
 " ======================
@@ -18,13 +22,13 @@
 " ======================================
 " Status line and Buffer line definition
 " ======================================
-  lua _G.statusline = require'bubbly.plugin'
-  lua _G.tabline = require'bubbly.factories.tabline'
+  lua _G.bubbly_statusline = require'bubbly.plugin'
+  lua _G.bubbly_tabline = require'bubbly.factories.tabline'
   augroup BubblyRender
     autocmd!
-    autocmd WinEnter,BufEnter * setlocal statusline=%!v:lua.statusline()
-    autocmd WinLeave,BufLeave * setlocal statusline=%!v:lua.statusline(1)
+    autocmd WinEnter,BufEnter * setlocal statusline=%!v:lua.bubbly_statusline()
+    autocmd WinLeave,BufLeave * setlocal statusline=%!v:lua.bubbly_statusline(1)
     if g:bubbly_tabline == 1
-      autocmd TabNew,TabLeave,TabClosed,TabEnter * set tabline=%!v:lua.tabline()
+      autocmd TabNew,TabLeave,TabClosed,TabEnter * set tabline=%!v:lua.bubbly_tabline()
     endif
   augroup end

--- a/plugin/bubbly.vim
+++ b/plugin/bubbly.vim
@@ -13,7 +13,7 @@
   lua _G.bubbly_highlight = require'bubbly.highlight'
   augroup BubblyHighlight
     autocmd!
-    autocmd VimEnter,ColorScheme * v:lua.bubbly_highlight()
+    autocmd VimEnter,ColorScheme * :call v:lua.bubbly_highlight()
   augroup end
 " ======================
 " Autocommand definition


### PR DESCRIPTION
It was programmed to execute the function that defines the highlights on every event. Should close #61. Testing required.