### PR TITLE
Changed g:bubbly_statusline default value

### DIFF
--- a/lua/bubbly/defaults.lua
+++ b/lua/bubbly/defaults.lua
@@ -196,9 +196,6 @@
       'truncate',
 
       'path',
-      'branch',
-      'signify',
-      'coc',
 
       'divisor',
 

--- a/readme.md
+++ b/readme.md
@@ -180,9 +180,6 @@ vim.g.bubbly_statusline = {
    'truncate',
 
    'path',
-   'branch',
-   'signify',
-   'coc',
 
    'divisor',
 


### PR DESCRIPTION
Deleted `coc`, `signify` and `branch` bubble from the default value,
because not everyone will have those plugins/programs installed by
default.