### PR TITLE
User a custom left and right character for each bubble.

### DIFF
--- a/lua/bubbly/factories/bubble.lua
+++ b/lua/bubbly/factories/bubble.lua
@@ -24,7 +24,7 @@ return function(list)
       end
    end
    -- Auxiliar function to know if data is last in the list
-   local function islast(current_index)
+   local function is_last(current_index)
       for i = current_index + 1, #list do
          if list[i] and type(list[i]) == 'table' and list[i].data and type(list[i].data) == 'string' and list[i].data ~= '' then
             return false
@@ -38,7 +38,7 @@ return function(list)
    for i, e in ipairs(list) do
       if e and type(e) == 'table' and e.data and type(e.data) == 'string' and e.data ~= '' then
          -- check if element is the last one
-         local islast = islast(i)
+         local islast = is_last(i)
          -- normalize style
          if not e.style or type(e.style) ~= 'string' then e.style = '' end
          -- normalize color
@@ -47,10 +47,14 @@ return function(list)
          if not e.pre or type(e.pre) ~= 'string' then e.pre = '' end
          -- normalize post
          if not e.post or type(e.post) ~= 'string' then e.post = '' end
+         -- normalize left
+         if not e.left or type(e.left) ~= 'string' then e.left = settings.left_character end
+         -- normalize right
+         if not e.right or type(e.right) ~= 'string' then e.right = settings.right_character end
          -- render pre
          bubble = bubble..e.pre
          -- render left delimiter
-         if isfirst then bubble = bubble..render_delimiter(settings.left_character, e.color) end
+         if isfirst then bubble = bubble..render_delimiter(e.left, e.color) end
          -- render data style
          if type(e.color) == 'string' then
             bubble = bubble..'%#'..gethighlight(nil, e.color, e.style) ..'#'
@@ -62,7 +66,7 @@ return function(list)
          bubble = bubble..e.data:gsub('^%s*(.-)%s*$', '%1')
          if not islast then bubble = bubble..' ' end
          -- render right delimiter
-         if islast then bubble = bubble..render_delimiter(settings.right_character, e.color)..'%#BubblyStatusLine#' end
+         if islast then bubble = bubble..render_delimiter(e.right, e.color)..'%#BubblyStatusLine#' end
          -- render post
          bubble = bubble..e.post
          -- disable isfirst

--- a/readme.md
+++ b/readme.md
@@ -520,7 +520,7 @@ function(inactive)
       -- Every table follows the following structure:
       {
          -- This is what the component shows in the statusline
-	 data = 'string',
+         data = 'string',
          -- This is what color the component uses when it is active. It should be the name of a color.
          color = 'string' or { foreground = 'string', background = 'string' },
          -- This is the style the component uses (optional).
@@ -529,6 +529,10 @@ function(inactive)
          pre = 'string',
          -- This is a string to place after the bubble (optional) (usually not used).
          post = 'string',
+         -- Overwrite the left character
+         left = 'string',
+         -- Overwrite the right character
+         right = 'string',
       },
    }
 end

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 Hello! _Bubbly_ is a plugin created by me with the intention of creating a good looking and efficient status line. _Bubbly_ is modular and easily extensible — more about this later in the [documentation for developers](#for-developers).
 
-As this plugin is tries to be truly modular, you can enable and disable its modules — or bubbles, as I like to call them — with a simple configuration.
+As this plugin tries to be truly modular, you can enable and disable its modules — or bubbles, as I like to call them — with a simple configuration.
 
 This plugin has support for these bubbles, feel free to open an issue or a pull request if you have an idea for a new bubble.
 


### PR DESCRIPTION
Hi,

I realized that with a small change in code, we could let the user decide the shape of the bubble: square? triangular?
Now I can achieve something like this:
![image](https://user-images.githubusercontent.com/1894436/110757237-74488580-824b-11eb-9354-1c1575b82a96.png)

Basically each module can return the `right` and `left` characters (or strings) and they will be used instead of the default.