### PR TITLE
Listen to FocusGained and VimResume

### DIFF
--- a/lua/bubbly/autocommands/branch.lua
+++ b/lua/bubbly/autocommands/branch.lua
@@ -4,7 +4,7 @@
 -- Created by datwaft <github.com/datwaft>
 
 return {{
-  events = { 'BufEnter' },
+  events = { 'BufEnter', 'FocusGained', 'VimResume' },
   variable = {
     type = 'buffer',
     name = 'bubbly_branch',


### PR DESCRIPTION
Hi, I'd like to update the branch bubble in more scenarios:
* FocusGained: switching terminal tabs
* VimResume: sending a suspended Neovim process back to the foreground (e.g. CTRL-z, fg)