### PR TITLE
Support custom filetype name mappings

### DIFF
--- a/lua/bubbly/components/filetype.lua
+++ b/lua/bubbly/components/filetype.lua
@@ -31,6 +31,8 @@ return function(inactive)
   local filetype = vim.bo.filetype
   if filetype == "" then
     filetype = settings.tag.noft
+  elseif settings.tag[filetype:lower()] ~= nil then
+    filetype = settings.tag[filetype:lower()]
   else
     filetype = filetype:lower()
   end

--- a/readme.md
+++ b/readme.md
@@ -364,6 +364,56 @@ vim.g.bubbly_tags = {
 }
 ```
 
+You can also map filetypes to custom names e.g.
+
+```lua
+vim.g.bubbly_tags = {
+  default = 'HELP ME PLEASE!',
+
+  mode = {
+    normal = 'NORMAL',
+    insert = 'INSERT',
+    visual = 'VISUAL',
+    visualblock = 'VISUAL-B',
+    command = 'COMMAND',
+    terminal = 'TERMINAL',
+    replace = 'REPLACE',
+    default = 'UNKOWN',
+  },
+  paste = 'PASTE',
+  filetype = {
+    noft = '<none>',
+    conf = ' config',
+    config = ' config',
+    css = ' css',
+    diff = '繁 diff',
+    dockerfile = ' docker',
+    email = ' mail',
+    gitconfig = ' git config',
+    html = ' html',
+    javascript = ' javascript',
+    javascriptreact = ' javascript',
+    json = ' json',
+    less = ' less',
+    lua = ' lua',
+    mail = ' mail',
+    make = ' make',
+    markdown = ' markdown',
+    php = ' php',
+    plain = ' text',
+    plaintext = ' text',
+    python = ' python',
+    sass = ' sass',
+    scss = ' scss',
+    text = ' text',
+    typescript = ' typescript',
+    typescriptreact = ' typescript',
+    vim = ' vim',
+    xml = '謹 xml',
+  },
+}
+```
+
 ### `g:bubbly_colors`
 
 This variable defines which colors is used by which bubble. Every color can be a string with the name of the color or a table with `foreground` and `background` keys, which define which color is used for foreground and background.


### PR DESCRIPTION
Allow people to create custom display names for filetypes in the filetype component

config example:

```lua
vim.g.bubbly_tags = {
  default = 'HELP ME PLEASE!',

  mode = {
    normal = 'NORMAL',
    insert = 'INSERT',
    visual = 'VISUAL',
    visualblock = 'VISUAL-B',
    command = 'COMMAND',
    terminal = 'TERMINAL',
    replace = 'REPLACE',
    default = 'UNKOWN',
  },
  paste = 'PASTE',
  filetype = {
    noft = '<none>',
    email = ' mail',
    mail = ' mail',
    text = ' text',
    plain = ' text',
    plaintext = ' text',
    markdown = ' markdown',
    json = ' json',
    conf = ' config',
    config = ' config',
    python = ' python',
    html = ' html',
    xml = '謹 xml',
    css = ' css',
    scss = ' scss',
    sass = ' sass',
    less = ' less',
    make = ' make',
    diff = '繁 diff',
    php = ' php',
    dockerfile = ' docker',
    gitconfig = ' git config',
    javascript = ' javascript',
    javascriptreact = ' javascript',
    typescript = ' typescript',
    typescriptreact = ' typescript',
    vim = ' vim',
  },
}
```